### PR TITLE
Fix typo. Change robots.tx to  robots.txt

### DIFF
--- a/.always_forget.txt
+++ b/.always_forget.txt
@@ -274,7 +274,7 @@ wget URL -O FILE                        # output to FILE
 wget --random-wait                      # avoid a blacklist with random timing
 wget -r                                 # recursive (default max depth 5)
 wget -p                                 # include all files, including images
-wget -e robots=off                      # disregard robots.tx
+wget -e robots=off                      # disregard robots.txt
 wget -U mozilla                         # browser identity
 wget --limit-rate=20k                   # reduce download rate
 wget -b                                 # background


### PR DESCRIPTION
Fixes small typo in .always_forget.txt. Changes robots.tx to robots.txt.